### PR TITLE
Fix invalid argument call for ModuleNotFoundError

### DIFF
--- a/modules/stats.py
+++ b/modules/stats.py
@@ -53,7 +53,7 @@ try:
     importpySMART = True
 
 except ImportError as error:
-    logger.error(error.message)
+    logger.error(error)
     importpySMARTerror = error
     importpySMART = False
 except Exception as e:


### PR DESCRIPTION
This fixes:
"AttributeError: 'ModuleNotFoundError' object has no attribute 'message'"

At least in Python 3 the ImportError exception has no "message" attribute:
- https://docs.python.org/3/library/exceptions.html#ImportError
The only and new Python 3.6 subclass ModuleNotFoundError does not add it:
- https://docs.python.org/3/library/exceptions.html#ModuleNotFoundError

Using "logger.error(error)" leads to this satisfying error message:
"modules.stats :: ERROR :: No module named 'pySMART'"