### PR TITLE
Minor CSS code quality and consistency tweaks

### DIFF
--- a/interfaces/default/css/about.css
+++ b/interfaces/default/css/about.css
@@ -1,3 +1,3 @@
-.table td{
-	border-top: 0px none #ddd !important;
+.table td {
+	border-top: 0 none #ddd !important;
 }

--- a/interfaces/default/css/bootstrap-slider.css
+++ b/interfaces/default/css/bootstrap-slider.css
@@ -3,7 +3,7 @@
  *
  * Copyright 2012 Stefan Petre
  * Licensed under the Apache License v2.0
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  */
  
@@ -11,132 +11,130 @@
 #ex1Slider .slider-selection {
 	background: #0e90d2 !important;
 }
-
- #ex1Slider {
+#ex1Slider {
 	width: 185px;
 }
- 
 .slider {
-  display: inline-block;
-  vertical-align: middle;
-  position: relative;
+	display: inline-block;
+	vertical-align: middle;
+	position: relative;
 }
 .slider.slider-horizontal {
-  width: 210px;
-  height: 20px;
+	width: 210px;
+	height: 20px;
 }
 .slider.slider-horizontal .slider-track {
-  height: 10px;
-  width: 100%;
-  margin-top: -5px;
-  top: 50%;
-  left: 0;
+	height: 10px;
+	width: 100%;
+	margin-top: -5px;
+	top: 50%;
+	left: 0;
 }
 .slider.slider-horizontal .slider-selection {
-  height: 100%;
-  top: 0;
-  bottom: 0;
+	height: 100%;
+	top: 0;
+	bottom: 0;
 }
 .slider.slider-horizontal .slider-handle {
-  margin-left: -10px;
-  margin-top: -5px;
+	margin-left: -10px;
+	margin-top: -5px;
 }
 .slider.slider-horizontal .slider-handle.triangle {
-  border-width: 0 10px 10px 10px;
-  width: 0;
-  height: 0;
-  border-bottom-color: #0480be;
-  margin-top: 0;
+	border-width: 0 10px 10px;
+	width: 0;
+	height: 0;
+	border-bottom-color: #0480be;
+	margin-top: 0;
 }
 .slider.slider-vertical {
-  height: 210px;
-  width: 20px;
+	height: 210px;
+	width: 20px;
 }
 .slider.slider-vertical .slider-track {
-  width: 10px;
-  height: 100%;
-  margin-left: -5px;
-  left: 50%;
-  top: 0;
+	width: 10px;
+	height: 100%;
+	margin-left: -5px;
+	left: 50%;
+	top: 0;
 }
 .slider.slider-vertical .slider-selection {
-  width: 100%;
-  left: 0;
-  top: 0;
-  bottom: 0;
+	width: 100%;
+	left: 0;
+	top: 0;
+	bottom: 0;
 }
 .slider.slider-vertical .slider-handle {
-  margin-left: -5px;
-  margin-top: -10px;
+	margin-left: -5px;
+	margin-top: -10px;
 }
 .slider.slider-vertical .slider-handle.triangle {
-  border-width: 10px 0 10px 10px;
-  width: 1px;
-  height: 1px;
-  border-left-color: #0480be;
-  margin-left: 0;
+	border-width: 10px 0 10px 10px;
+	width: 1px;
+	height: 1px;
+	border-left-color: #0480be;
+	margin-left: 0;
 }
 .slider.slider-disabled .slider-handle {
-  background-image: -webkit-linear-gradient(top, #dfdfdf 0%, #bebebe 100%);
-  background-image: linear-gradient(to bottom, #dfdfdf 0%, #bebebe 100%);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffdfdfdf', endColorstr='#ffbebebe', GradientType=0);
+	background-image: -webkit-linear-gradient(top, #dfdfdf 0%, #bebebe 100%);
+	background-image: linear-gradient(to bottom, #dfdfdf 0%, #bebebe 100%);
+	background-repeat: repeat-x;
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffdfdfdf', endColorstr='#ffbebebe', GradientType=0);
 }
 .slider.slider-disabled .slider-track {
-  background-image: -webkit-linear-gradient(top, #e5e5e5 0%, #e9e9e9 100%);
-  background-image: linear-gradient(to bottom, #e5e5e5 0%, #e9e9e9 100%);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffe5e5e5', endColorstr='#ffe9e9e9', GradientType=0);
-  cursor: not-allowed;
+	background-image: -webkit-linear-gradient(top, #e5e5e5 0%, #e9e9e9 100%);
+	background-image: linear-gradient(to bottom, #e5e5e5 0%, #e9e9e9 100%);
+	background-repeat: repeat-x;
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffe5e5e5', endColorstr='#ffe9e9e9', GradientType=0);
+	cursor: not-allowed;
 }
 .slider input {
-  display: none;
+	display: none;
 }
 .slider .tooltip-inner {
-  white-space: nowrap;
+	white-space: nowrap;
 }
 .slider-track {
-  position: absolute;
-  cursor: pointer;
-  background-image: -webkit-linear-gradient(top, #f5f5f5 0%, #f9f9f9 100%);
-  background-image: linear-gradient(to bottom, #f5f5f5 0%, #f9f9f9 100%);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff5f5f5', endColorstr='#fff9f9f9', GradientType=0);
-  -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-  border-radius: 4px;
+	position: absolute;
+	cursor: pointer;
+	background-image: -webkit-linear-gradient(top, #f5f5f5 0%, #f9f9f9 100%);
+	background-image: linear-gradient(to bottom, #f5f5f5 0%, #f9f9f9 100%);
+	background-repeat: repeat-x;
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff5f5f5', endColorstr='#fff9f9f9', GradientType=0);
+	-webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+	box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+	border-radius: 4px;
 }
 .slider-selection {
-  position: absolute;
-  background-image: -webkit-linear-gradient(top, #f9f9f9 0%, #f5f5f5 100%);
-  background-image: linear-gradient(to bottom, #f9f9f9 0%, #f5f5f5 100%);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff9f9f9', endColorstr='#fff5f5f5', GradientType=0);
-  -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
-  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
-  border-radius: 4px;
+	position: absolute;
+	background-image: -webkit-linear-gradient(top, #f9f9f9 0%, #f5f5f5 100%);
+	background-image: linear-gradient(to bottom, #f9f9f9 0%, #f5f5f5 100%);
+	background-repeat: repeat-x;
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff9f9f9', endColorstr='#fff5f5f5', GradientType=0);
+	-webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+	box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+	border-radius: 4px;
 }
 .slider-handle {
-  position: absolute;
-  width: 20px;
-  height: 20px;
-  background-color: ##0e90d2; /*  Org #3a94a5 */
-  background-image: -webkit-linear-gradient(top, #149bdf 0%, #0480be 100%);
-  background-image: linear-gradient(to bottom, #149bdf 0%, #0480be 100%);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff149bdf', endColorstr='#ff0480be', GradientType=0);
-  filter: none;
-  -webkit-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
-  opacity: 0.8;
-  border: 0px solid transparent;
+	position: absolute;
+	width: 20px;
+	height: 20px;
+	background-color: ##0e90d2; /* Org #3a94a5 */
+	background-image: -webkit-linear-gradient(top, #149bdf 0%, #0480be 100%);
+	background-image: linear-gradient(to bottom, #149bdf 0%, #0480be 100%);
+	background-repeat: repeat-x;
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff149bdf', endColorstr='#ff0480be', GradientType=0);
+	filter: none;
+	-webkit-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+	box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+	opacity: 0.8;
+	border: 0 solid transparent;
 }
 .slider-handle.round {
-  border-radius: 50%;
+	border-radius: 50%;
 }
 .slider-handle.triangle {
-  background: transparent none;
+	background: transparent none;
 }

--- a/interfaces/default/css/couchpotato.css
+++ b/interfaces/default/css/couchpotato.css
@@ -1,60 +1,58 @@
 .thumbnails li {
-    position: relative;
+	position: relative;
 	width: auto;
 	height: 175px;
 	text-align: center;
-    float: left;
+	float: left;
 }
-
 #wanted-grid img.thumbnail,
 #result-grid img.thumbnail {
-    height: 150px;
-    width: 100px;
+	height: 150px;
+	width: 100px;
 }
-
 #wanted-grid
 #wanted-grid #result-grid h6.movie-title {
-    color: #555555;
-    text-align: center;
-    margin: 0;
-    padding-top: 4px;
+	color: #555555;
+	text-align: center;
+	margin: 0;
+	padding-top: 4px;
 }
 #wanted-grid a:Hover,
 #result-grid a:Hover {
-    text-decoration: none;
+	text-decoration: none;
 }
 .status {
-    position: absolute;
-    top: 138px;
-    right: 5px;
-    width: 16px;
-    height: 16px;
+	position: absolute;
+	top: 138px;
+	right: 5px;
+	width: 16px;
+	height: 16px;
 }
 .modal-fanart {
-    background: #fff top center no-repeat;
-    background-size: 100%;
+	background: #fff top center no-repeat;
+	background-size: 100%;
 }
 .modal-body td i {
-    margin-right: 5px;
+	margin-right: 5px;
 }
 .modal-body .ignore {
-    text-decoration: line-through;
+	text-decoration: line-through;
 }
 .modal img.thumbnail {
-    height: 231px;
-    width: 154px;
+	height: 231px;
+	width: 154px;
 }
 .modal .modal-movieinfo {
-    margin-left: 180px;
+	margin-left: 180px;
 }
 .modal .modal-movieinfo select {
-    margin-top: 10px;
+	margin-top: 10px;
 }
-
 @media (max-width: 767px) {
-.thumbnails>li{margin-left:4px}
+	.thumbnails > li {
+		margin-left: 4px
+	}
 }
-
 @media (max-width: 320px) {
 	.modal .movie-poster {
 		height: 207px !important;
@@ -64,14 +62,14 @@
 		max-height: 280px;
 	}
 	.thumbnails>li {
-		padding: 0px;
+		padding: 0;
 		margin-left: 17px !important;
 	}
 	.thumbnail {
 		padding: 6px;
-        margin-right: 5px;
+		margin-right: 5px;
 	}
 	.modal .modal-movieinfo {
-		margin-left: 0px;
+		margin-left: 0;
 	}
 }

--- a/interfaces/default/css/dash.css
+++ b/interfaces/default/css/dash.css
@@ -1,129 +1,119 @@
 .span4 thead {
-    display: none;
+	display: none;
 }
 .alignright {
-    text-align: right !important;
+	text-align: right !important;
 }
 .aligncenter {
-    text-align: center !important;
+	text-align: center !important;
 }
 .carousel-item {
-    height: 200px;
-    background-position: center 20%;
-    background-size: cover;
-    background-repeat: no-repeat;
+	height: 200px;
+	background-position: center 20%;
+	background-size: cover;
+	background-repeat: no-repeat;
 }
 .carousel-control.left {
 	background: none;
 	border: none;
-	left: 0px;
+	left: 0;
 	opacity: 0.7;
 }
 .carousel-control.right {
 	background: none;
 	border: none;
-	right: 0px;
+	right: 0;
 	opacity: 0.7;
 }
 .carousel-caption h4 {
-    font-weight: normal;
-    font-size: small;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-    cursor: pointer;
-    line-height: 15px;
+	font-weight: normal;
+	font-size: small;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	overflow: hidden;
+	cursor: pointer;
+	line-height: 15px;
 }
 .carousel-caption p {
-    font-size: smaller;
-    height: 150px;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    cursor: pointer;
+	font-size: smaller;
+	height: 150px;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	cursor: pointer;
 }
 .movie-poster {
-    height: 300px;
-    width: 200px;
+	height: 300px;
+	width: 200px;
 }
 .media {
-    margin: 0;
-    cursor: pointer;
+	margin: 0;
+	cursor: pointer;
 }
 .dashboard .media-object {
-    height: 45px;
-    width: 45px;
+	height: 45px;
+	width: 45px;
 }
-.dashboard .span4 table{
-    table-layout: fixed;
+.dashboard .span4 table {
+	table-layout: fixed;
 }
-.dashboard .span4 td{
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
+.dashboard .span4 td {
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	overflow: hidden;
 }
 .dashboard .span4 #downloads_table_body td:last-child {
-    width: 14px;
+	width: 14px;
 }
 .dashboard .span4 #nzbgetdownloads_table_body td:last-child {
-    width: 14px;
+	width: 14px;
 }
 .dash-module-edit{
-    min-height: 140px !important;
-    border: 1px solid !important;
-    border-color: #FFFF00 !important;
-    max-height: 140px !important;
-    height: 140px !important;
-    overflow: hidden !important;
-    cursor: move;
-
+	min-height: 140px !important;
+	border: 1px solid !important;
+	border-color: #FFFF00 !important;
+	max-height: 140px !important;
+	height: 140px !important;
+	overflow: hidden !important;
+	cursor: move;
 }
-
 .dash-row-edit {
-    min-height: 150px !important;
-    border: 1px solid !important;
-    border-color: #FF0000 !important;
-    margin-bottom: 10px !important;
-    padding: 5px !important;
+	min-height: 150px !important;
+	border: 1px solid !important;
+	border-color: #FF0000 !important;
+	margin-bottom: 10px !important;
+	padding: 5px !important;
 }
-
 .refresh-btns{
-    float: right !important;
+	float: right !important;
 }
-
 /*
-#dash_sysinfo_table_body div{
-    width:50%;
-    display:inline-block
+#dash_sysinfo_table_body div {
+	width: 50%;
+	display: inline-block
 }
-
-#dash_sysinfo_table_body td{
-    text-align: center !important;
+#dash_sysinfo_table_body td {
+	text-align: center !important;
 }
-
-
-#dash_sysinfo_table_body tr td:first-of-type{
-    text-align: left !important;
+#dash_sysinfo_table_body tr td:first-of-type {
+	text-align: left !important;
 }
 */
 #dash_disks_table_body .progress,
-#dash_sysinfo_table_body .progress{
-    margin-bottom:0px !important;
+#dash_sysinfo_table_body .progress {
+	margin-bottom: 0 !important;
 }
-#editButtons{
-    display: None;
+#editButtons {
+	display: none;
 }
-
 .stretchedbg {
 	background-size: 100% 100%;
-    background-repeat: no-repeat;
+	background-repeat: no-repeat;
 }
-
 #dash_smart .table,
 #dash_sysinfo .table,
-#dash_disks .table{
-  table-layout: auto !important;
+#dash_disks .table {
+	table-layout: auto !important;
 }
-
 .ip{
-width:360px;
+	width: 360px;
 }

--- a/interfaces/default/css/deluge.css
+++ b/interfaces/default/css/deluge.css
@@ -1,4 +1,3 @@
-
 #torrent-queue .progress {
-	margin-bottom: 0px !important;
+	margin-bottom: 0 !important;
 }

--- a/interfaces/default/css/headphones_view_album.css
+++ b/interfaces/default/css/headphones_view_album.css
@@ -1,87 +1,73 @@
-table td{
+table td {
 	vertical-align: middle !important;
 }
-
 .album_img {
-  max-width: 300px;
-  height: 250px;
-  width: 250px;
-
+	max-width: 300px;
+	height: 250px;
+	width: 250px;
 }
-
 #banner {
-  margin-bottom: 15px;
+	margin-bottom: 15px;
 }
-.headphones_album .banner{
-  position: relative;
-  border-radius: 6px 0px 0px 6px;
-  background:  center left no-repeat ;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
-  margin-bottom: 15px;
+.headphones_album .banner {
+	position: relative;
+	border-radius: 6px 0 0 6px;
+	background: center left no-repeat ;
+	-webkit-background-size: cover;
+	-moz-background-size: cover;
+	-o-background-size: cover;
+	background-size: cover;
+	margin-bottom: 15px;
 }
-
 .headphones_album .banner .album_details {
-    background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-    color: White;
-    overflow:hidden;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	color: White;
+	overflow: hidden;
 }
-.headphones_album .banner .album_details #album_details_top{
-  background: Red;
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  top: -15px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 6px 6px 0px 0px;
+.headphones_album .banner .album_details #album_details_top {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	top: -15px;
+	background: Red;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 6px 6px 0 0;
 }
-
-.headphones_album .banner .album_details #album_details_bottom{
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  margin-left: 0px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 0px 0px 6px 6px;
+.headphones_album .banner .album_details #album_details_bottom {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	margin-left: 0;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 0 0 6px 6px;
 }
-
-.headphones_album .banner .album_details td{
-  padding: 2px 5px;
+.headphones_album .banner .album_details td {
+	padding: 2px 5px;
 }
-
 .headphones_album .banner .album_details table,
 .headphones_album .banner .album_details strong {
-  margin:10px;
+	margin: 10px;
 }
-
-@media all and  (max-width: 767px) {
-  /*
-   * On small screens, remove top and bottom round bars on album-detail block
-   */
-  .headphones_album .banner .album_details #album_details_bottom,
-  .headphones_album .banner .album_details #album_details_top{
-    display: none;
-  }
-  .album_img {
-    display: none;
-  }
-  /*
-   * On small screens, Add rounded corners on all sides on banner and detail-box
-   */
-  .headphones_album .banner .album_details,
-  .headphones_album .banner{
-    border-radius: 6px;
-  }
+@media all and (max-width: 767px) {
+	/* On small screens, remove top and bottom round bars on album-detail block */
+	.headphones_album .banner .album_details #album_details_bottom,
+	.headphones_album .banner .album_details #album_details_top {
+		display: none;
+	}
+	.album_img {
+		display: none;
+	}
+	/* On small screens, Add rounded corners on all sides on banner and detail-box */
+	.headphones_album .banner .album_details,
+	.headphones_album .banner {
+		border-radius: 6px;
+	}
 }
-
 .episodeinfo tr {
 	border-bottom: 1px solid #CCCCCC;
 }
-
 .episodeinfo  td {
 	width: auto;
 	padding-right: 20px;

--- a/interfaces/default/css/headphones_view_artist.css
+++ b/interfaces/default/css/headphones_view_artist.css
@@ -1,88 +1,74 @@
-table td{
+table td {
 	vertical-align: middle !important;
 }
-
 .artist_img {
-  max-width: 300px;
-  height: 250px;
-  //width: 250px;
-
+	max-width: 300px;
+	height: 250px;
+	/* width: 250px; */
 }
-
 #banner {
-  margin-bottom: 15 px;
+	margin-bottom: 15 px;
 }
-
-.headphones_artist .banner{
-  position: relative;
-  border-radius: 6px 0px 0px 6px;
-  background:  center left no-repeat ;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
-  margin-bottom: 15px;
+.headphones_artist .banner {
+	position: relative;
+	border-radius: 6px 0 0 6px;
+	background: center left no-repeat ;
+	-webkit-background-size: cover;
+	-moz-background-size: cover;
+	-o-background-size: cover;
+	background-size: cover;
+	margin-bottom: 15px;
 }
-
 .headphones_artist .banner .artist_details {
-    background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-    color: White;
-    overflow:hidden;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	color: White;
+	overflow:hidden;
 }
-.headphones_artist .banner .artist_details #artist_details_top{
-  background: Red;
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  top: -15px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 6px 6px 0px 0px;
+.headphones_artist .banner .artist_details #artist_details_top {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	top: -15px;
+	background: Red;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 6px 6px 0 0;
 }
-
-.headphones_artist .banner .artist_details #artist_details_bottom{
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  margin-left: 0px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 0px 0px 6px 6px;
+.headphones_artist .banner .artist_details #artist_details_bottom {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	margin-left: 0;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 0 0 6px 6px;
 }
-
-.headphones_artist .banner .artist_details td{
-  padding: 2px 5px;
+.headphones_artist .banner .artist_details td {
+	padding: 2px 5px;
 }
 
 .headphones_artist .banner .artist_details table,
 .headphones_artist .banner .artist_details strong {
-  margin:10px;
+	margin: 10px;
 }
-
-@media all and  (max-width: 767px) {
-  /*
-   * On small screens, remove top and bottom round bars on artist-detail block
-   */
-  .headphones_artist .banner .artist_details #artist_details_bottom,
-  .headphones_artist .banner .artist_details #artist_details_top{
-    display: none;
-  }
-  .artist_img {
-    display: none;
-  }
-  /*
-   * On small screens, Add rounded corners on all sides on banner and detail-box
-   */
-  .headphones_artist .banner .artist_details,
-  .headphones_artist .banner{
-    border-radius: 6px;
-  }
+@media all and (max-width: 767px) {
+	/* On small screens, remove top and bottom round bars on artist-detail block */
+	.headphones_artist .banner .artist_details #artist_details_bottom,
+	.headphones_artist .banner .artist_details #artist_details_top {
+		display: none;
+	}
+	.artist_img {
+		display: none;
+	}
+	/* On small screens, Add rounded corners on all sides on banner and detail-box */
+	.headphones_artist .banner .artist_details,
+	.headphones_artist .banner {
+		border-radius: 6px;
+	}
 }
-
 .episodeinfo tr {
 	border-bottom: 1px solid #CCCCCC;
 }
-
 .episodeinfo  td {
 	width: auto;
 	padding-right: 20px;

--- a/interfaces/default/css/iframe.css
+++ b/interfaces/default/css/iframe.css
@@ -1,12 +1,11 @@
 body, html {
-	overflow:hidden;
+	overflow: hidden;
 }
-
 #webpage {
-width: 100%;
-border: none;
-margin: 0px;
-position: absolute;
-left: 0px;
-right: 0px;
+	width: 100%;
+	border: none;
+	margin: 0;
+	position: absolute;
+	left: 0;
+	right: 0;
 }

--- a/interfaces/default/css/kodi.css
+++ b/interfaces/default/css/kodi.css
@@ -1,179 +1,175 @@
 a:Hover {
-    text-decoration: none;
+	text-decoration: none;
 }
 .thumbnails li {
-    position: relative;
+	position: relative;
 	float: left;
 }
 #addons-grid img.thumbnail,
 #movie-grid img.thumbnail,
 #show-grid img.thumbnail {
-    height: 150px;
-    width: 100px;
+	height: 150px;
+	width: 100px;
 }
 #episode-grid img.thumbnail {
-    position: relative;
-    height: 85px;
-    width: 150px;
+	position: relative;
+	height: 85px;
+	width: 150px;
 }
 #album-grid img.thumbnail,
 #artist-grid img.thumbnail {
-    height: 150px;
-    width: 150px;
+	height: 150px;
+	width: 150px;
 }
 #pvr-grid img.thumbnail {
-    height: 75px;
-    width: 75px;
+	height: 75px;
+	width: 75px;
 }
-
 .watched {
-    position: absolute;
-    top: 138px;
-    right: 5px;
-    width: 16px;
-    height: 16px;
+	position: absolute;
+	top: 138px;
+	right: 5px;
+	width: 16px;
+	height: 16px;
 }
 .watched-episode {
-    position: absolute;
-    top: 74px;
-    right: 4px;
-    width: 16px;
-    height: 16px;
+	position: absolute;
+	top: 74px;
+	right: 4px;
+	width: 16px;
+	height: 16px;
 }
 .grid-caption {
-    position: absolute;
-    bottom: 5px;
-    left: 5px;
-    background: rgba(0,0,0,0.75);
-    padding: 10px;
-    width: 130px;
-    height: 130px;
+	position: absolute;
+	bottom: 5px;
+	left: 5px;
+	background: rgba(0,0,0,0.75);
+	padding: 10px;
+	width: 130px;
+	height: 130px;
 }
 .grid-caption h6 {
-    color: #fff;
-    font-family: inherit;
-    margin: 0;
+	color: #fff;
+	font-family: inherit;
+	margin: 0;
 }
 .grid-caption h6.artist {
-    font-weight: normal;
+	font-weight: normal;
 }
 .grid-control {
-    position: absolute;
-    bottom: 10px;
-    left: 10px;
+	position: absolute;
+	bottom: 10px;
+	left: 10px;
 }
 .grid-control a:first-child {
-    margin-right: 35px;
+	margin-right: 35px;
 }
 h6.title {
-    color: #555555;
-    text-align: center;
-    margin: 0;
-    padding-top: 4px;
+	color: #555555;
+	text-align: center;
+	margin: 0;
+	padding-top: 4px;
 }
 #artist-grid tr td:first-child {
-    width: 35px;
+	width: 35px;
 }
 #artist-grid a.artist-link {
-    display: block;
+	display: block;
 }
 #artist-grid i,
 #playlist-table i {
-    margin: 0 5px 0 0;
+	margin: 0 5px 0 0;
 }
 #nowplaying #player-progressbar,
 #playlist tr td {
-    cursor: pointer;
+	cursor: pointer;
 }
 #player-volume-progressbar {
 	height: 25px !important;
-	margin: 0px !important;
+	margin: 0 !important;
 	cursor: pointer;
 	background-color: #222222 !important;
 }
 #nowplaying {
-    background-size: 100%;
-    background-position: 50% 20%;
-    background-repeat: no-repeat;
-    margin-bottom: 10px;
+	background-size: 100%;
+	background-position: 50% 20%;
+	background-repeat: no-repeat;
+	margin-bottom: 10px;
 }
 #playlist-table tr td:last-child {
-    width: 35px;
+	width: 35px;
 }
 .modal-fanart {
-    background: #fff top center no-repeat;
-    background-size: 100%;
+	background: #fff top center no-repeat;
+	background-size: 100%;
 }
 .modal .movie-poster {
-    height: 300px;
-    width: 200px;
+	height: 300px;
+	width: 200px;
 }
 .modal .episode-poster {
-    height: 100px;
-    width: 150px;
+	height: 100px;
+	width: 150px;
 }
 /*
 .modal .modal-movieinfo {
-    margin-left: 171px;
+	margin-left: 171px;
 }
 */
 .modal .modal-episodeinfo {
-    margin-left: 171px;
+	margin-left: 171px;
 }
-
 .modal-body {
 	overflow: hidden;
 }
-
 .modal .modal-youtube {
-    border: 0;
-    height: 400px;
+	border: 0;
+	height: 400px;
 	width: 100%;
 	overflow: hidden;
 }
-
 @media (max-width: 767px) {
-.thumbnails>li{margin-left:4px}
+	.thumbnails > li {
+		margin-left: 4px
+	}
 }
-
 @media (max-width: 320px) {
 	.modal .movie-poster {
 		height: 207px !important;
 		width: 144px !important;
-        margin-right: 8px;
+		margin-right: 8px;
 	}
-    .page-header .header-toolbar {
-        margin-top: 10px!important;
-    }
+	.page-header .header-toolbar {
+		margin-top: 10px !important;
+	}
 	.modal-body {
 		max-height: 280px;
 	}
 	.modal .modal-youtube {
 		max-height: 200px;
 	}
-    #episode-grid.thumbnails>li {
-        padding: 0px;
-        margin-left: 63px !important;
-
-    }
-	.thumbnails>li {
-		padding: 0px;
+	#episode-grid.thumbnails > li {
+		padding: 0;
+		margin-left: 63px !important;
+	}
+	.thumbnails > li {
+		padding: 0;
 		margin-left: 15px !important;
 	}
 	.thumbnail {
 		padding: 6px;
 	}
 	.modal .modal-movieinfo {
-		margin-left: 0px;
+		margin-left: 0;
 	}
-    .modal .modal-episodeinfo {
-        margin-left: 0px;
-    }
-    .modal .episode-poster {
-        margin-right: 8px;
-    }
-    .dropdown-menu {
-        right:initial!important;
-        left: 0 !important;
-    }
+	.modal .modal-episodeinfo {
+		margin-left: 0;
+	}
+	.modal .episode-poster {
+		margin-right: 8px;
+	}
+	.dropdown-menu {
+		right: initial !important;
+		left: 0 !important;
+	}
 }

--- a/interfaces/default/css/mylar_view_album.css
+++ b/interfaces/default/css/mylar_view_album.css
@@ -1,88 +1,76 @@
-table td{
+table td {
 	vertical-align: middle !important;
 }
-
 .album_img {
-  max-width: 300px;
-  height: 250px;
-  width: 250px;
-
+	max-width: 300px;
+	height: 250px;
+	width: 250px;
 }
-
 #banner {
-  margin-bottom: 15px;
+	margin-bottom: 15px;
 }
-.headphones_album .banner{
-  position: relative;
-  border-radius: 6px 0px 0px 6px;
-  background:  center left no-repeat ;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
-  margin-bottom: 15px;
+.headphones_album .banner {
+	position: relative;
+	border-radius: 6px 0 0 6px;
+	background: center left no-repeat ;
+	-webkit-background-size: cover;
+	-moz-background-size: cover;
+	-o-background-size: cover;
+	background-size: cover;
+	margin-bottom: 15px;
 }
-
 .headphones_album .banner .album_details {
-    background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-    color: White;
-    overflow:hidden;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	color: White;
+	overflow: hidden;
 }
-.headphones_album .banner .album_details #album_details_top{
-  background: Red;
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  top: -15px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 6px 6px 0px 0px;
+.headphones_album .banner .album_details #album_details_top {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	top: -15px;
+	background: Red;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 6px 6px 0 0;
 }
-
-.headphones_album .banner .album_details #album_details_bottom{
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  margin-left: 0px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 0px 0px 6px 6px;
+.headphones_album .banner .album_details #album_details_bottom {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	margin-left: 0;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 0 0 6px 6px;
 }
-
-.headphones_album .banner .album_details td{
-  padding: 2px 5px;
+.headphones_album .banner .album_details td {
+	padding: 2px 5px;
 }
 
 .headphones_album .banner .album_details table,
 .headphones_album .banner .album_details strong {
-  margin:10px;
+	margin: 10px;
 }
 
-@media all and  (max-width: 767px) {
-  /*
-   * On small screens, remove top and bottom round bars on album-detail block
-   */
-  .headphones_album .banner .album_details #album_details_bottom,
-  .headphones_album .banner .album_details #album_details_top{
-    display: none;
-  }
-  .album_img {
-    display: none;
-  }
-  /*
-   * On small screens, Add rounded corners on all sides on banner and detail-box
-   */
-  .headphones_album .banner .album_details,
-  .headphones_album .banner{
-    border-radius: 6px;
-  }
+@media all and (max-width: 767px) {
+	/* On small screens, remove top and bottom round bars on album-detail block */
+	.headphones_album .banner .album_details #album_details_bottom,
+	.headphones_album .banner .album_details #album_details_top {
+		display: none;
+	}
+	.album_img {
+		display: none;
+	}
+	/* On small screens, Add rounded corners on all sides on banner and detail-box */
+	.headphones_album .banner .album_details,
+	.headphones_album .banner {
+		border-radius: 6px;
+	}
 }
-
 .episodeinfo tr {
 	border-bottom: 1px solid #CCCCCC;
 }
-
-.episodeinfo  td {
+.episodeinfo td {
 	width: auto;
 	padding-right: 20px;
 }

--- a/interfaces/default/css/mylar_view_comic.css
+++ b/interfaces/default/css/mylar_view_comic.css
@@ -1,86 +1,72 @@
-table td{
+table td {
 	vertical-align: middle !important;
 }
-
 .comic_img {
-  height: 525px;
+	height: 525px;
 }
-
 #banner {
-  margin-bottom: 15 px;
+	margin-bottom: 15px;
 }
-
-.mylar_comic .banner{
-  position: relative;
-  border-radius: 6px 0px 0px 6px;
-  background:  center left no-repeat ;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
-  margin-bottom: 15px;
+.mylar_comic .banner {
+	position: relative;
+	border-radius: 6px 0 0 6px;
+	background: center left no-repeat;
+	-webkit-background-size: cover;
+	-moz-background-size: cover;
+	-o-background-size: cover;
+	background-size: cover;
+	margin-bottom: 15px;
 }
-
 .mylar_comic .banner .comic_details {
-    background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-    color: White;
-    overflow:hidden;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	color: White;
+	overflow: hidden;
 }
-.mylar_comic .banner .comic_details #comic_details_top{
-  background: Red;
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  top: -15px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 6px 6px 0px 0px;
+.mylar_comic .banner .comic_details #comic_details_top {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	top: -15px;
+	background: Red;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 6px 6px 0 0;
 }
-
-.mylar_comic .banner .comic_details #comic_details_bottom{
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  margin-left: 0px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 0px 0px 6px 6px;
+.mylar_comic .banner .comic_details #comic_details_bottom {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	margin-left: 0;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 0 0 6px 6px;
 }
-
-.mylar_comic .banner .comic_details td{
-  padding: 2px 5px;
+.mylar_comic .banner .comic_details td {
+	padding: 2px 5px;
 }
-
 .mylar_comic .banner .comic_details table,
 .mylar_comic .banner .comic_details strong {
-  margin:10px;
+	margin:10px;
 }
-
-@media all and  (max-width: 767px) {
-  /*
-   * On small screens, remove top and bottom round bars on comic-detail block
-   */
-  .mylar_comic .banner .comic_details #comic_details_bottom,
-  .mylar_comic .banner .comic_details #comic_details_top{
-    display: none;
-  }
-  .comic_img {
-    display: none;
-  }
-  /*
-   * On small screens, Add rounded corners on all sides on banner and detail-box
-   */
-  .mylar_comic .banner .comic_details,
-  .mylar_comic .banner{
-    border-radius: 6px;
-  }
+@media all and (max-width: 767px) {
+	/* On small screens, remove top and bottom round bars on comic-detail block */
+	.mylar_comic .banner .comic_details #comic_details_bottom,
+	.mylar_comic .banner .comic_details #comic_details_top {
+		display: none;
+	}
+	.comic_img {
+		display: none;
+	}
+	/* On small screens, Add rounded corners on all sides on banner and detail-box */
+	.mylar_comic .banner .comic_details,
+	.mylar_comic .banner {
+		border-radius: 6px;
+	}
 }
-
 .episodeinfo tr {
 	border-bottom: 1px solid #CCCCCC;
 }
-
-.episodeinfo  td {
+.episodeinfo td {
 	width: auto;
 	padding-right: 20px;
 }

--- a/interfaces/default/css/nzbget.css
+++ b/interfaces/default/css/nzbget.css
@@ -1,24 +1,20 @@
 .progress {
-    position: relative;
-    margin-bottom: 0px;
+	position: relative;
+	margin-bottom: 0;
 }
-
 .bar {
-    z-index: 1;
-    position: absolute;
+	z-index: 1;
+	position: absolute;
 }
-
 .progress span {
-    position: absolute;
-    top: 0;
-    z-index: 2;
-    text-align: center;
-    width: 100%;
-    color: black;
+	position: absolute;
+	top: 0;
+	z-index: 2;
+	text-align: center;
+	width: 100%;
+	color: black;
 }
-
-
 /* category dropdown */
 #active_table_body > tr > td:nth-child(3) > select {
-    margin-bottom: 0px;
+	margin-bottom: 0;
 }

--- a/interfaces/default/css/ombi.css
+++ b/interfaces/default/css/ombi.css
@@ -1,45 +1,40 @@
 .spinner {
-	top:	50%;
-	left:	50%;
-	transform:	translate(-50%,-50%);
-    -ms-transform:	translate(-50%,-50%);
-	display:	none;
-	position:	fixed;
-	z-index:	9999;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	-ms-transform: translate(-50%, -50%);
+	display: none;
+	position: fixed;
+	z-index: 9999;
 }
-
 .btn-ombiblue {
-	background-color:	hsl(194, 87%, 44%) !important;
+	background-color: hsl(194, 87%, 44%) !important;
 }
 .btn-ombiblue:hover {
-	background-color:	hsl(194, 77%, 39%) !important;
+	background-color: hsl(194, 77%, 39%) !important;
 }
-
 .btn-ombi-close {
-	float: 			right;
-	border: 		solid white 0.7px;
-	padding-top:	2px;
-	padding-bottom:	0px;
-	padding-left:	4px;
-	padding-right:	4px;
+	float: right;
+	border: solid white 0.7px;
+	padding-top: 2px;
+	padding-bottom:	0;
+	padding-left: 4px;
+	padding-right: 4px;
 }
-
 .ombi-actions {
-	display: inline-block;
 	position: absolute;
 	border-radius: 5px !important;
 	/* background-color: hsla(24, 5%, 5%, 0.85); */
 	background-color: hsla(24, 0%, 25%, 1);
 	padding: 5px;
+	display: inline-block;
 	display: none;
 	margin-top: -2px;
-	margin-left: 0px;
+	margin-left: 0;
 }
-
 .accordion {
-	overflow:	auto;
+	overflow: auto;
 }
-
 .ombi-tvrequest-detail {
 	position: absolute;
 	border-radius: 5px !important;
@@ -48,114 +43,98 @@
 	visibility: hidden;
 	/* display: none; */
 	/* width: 94%; */
-    /* top: 155px; */
-    left: -5px;
+	/* top: 155px; */
+	left: -5px;
 	z-index: 2030;
 	overflow: auto;
 }
-
 .ombi-req-overlay {
-	border: solid 2px; /* #df691a  */
-	width:	80%;
+	border: solid 2px; /* #df691a */
+	width: 80%;
 	height:	92%;
-	top:	50%;
-	left:	50%;
-	transform:	translate(-50%,-50%);
-    -ms-transform:	translate(-50%,-50%);
-	display:	none;
-	position:	fixed;
-	padding:	5px;
-	/* overflow:	auto; */
-	z-index:	2030;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	-ms-transform: translate(-50%, -50%);
+	display: none;
+	position: fixed;
+	padding: 5px;
+	/* overflow: auto; */
+	z-index: 2030;
 }
-
 .pseudoheader {
-		padding-top:	0px !important;
-		padding-bottom:	2px !important;
+	padding-top: 0 !important;
+	padding-bottom: 2px !important;
 }
-
 .pseudoheader-toggle {
-	padding-top:	2px !important;
-	text-align:	right !important;
+	padding-top: 2px !important;
+	text-align: right !important;
 }
-
 .seasonTabs {
 	overflow-y: auto !important;
 }
-
 .ombi-tvshow-request {
-	display:	none;
-	width:	100%;
+	display: none;
+	width: 100%;
 }
-
 @media (max-width: 767px) {
 	.ombi-tvrequest-detail {
 		padding: 2px;
-		border-radius: 0px !important;
+		border-radius: 0 !important;
 		width: 100%;
-		left: 0px;
+		left: 0;
 	}
-
 	.ombi-req-overlay {
-		width: 	96%;
-		height:	96%;
+		width: 96%;
+		height: 96%;
 	}
 }
-
 .btn-ombi-suggestion {
 	 margin-top: 2px;
 	 margin-bottom: 2px;
 }
-
 .ombi-menu-disabled {
 	color: gray !important;
 }
 h1.page-header.page-title a.ombi-menu-disabled {
 	color: gray !important;
 }
-
 .btn-ombi {
-	border-radius:	5px !important;
-	padding-top:	3px;
-	padding-bottom:	3px;
-	padding-left:	4px;
-	padding-right:	8px;
-	margin-right:	3px;
-	margin-top:		0px;
-	margin-bottom:	0px;
+	border-radius: 5px !important;
+	padding-top: 3px;
+	padding-bottom: 3px;
+	padding-left: 4px;
+	padding-right: 8px;
+	margin-right: 3px;
+	margin-top: 0;
+	margin-bottom: 0;
 }
-
 .btn-group-ombi {
-	border-radius:	5px !important;
-	padding-top:	3px;
-	padding-bottom:	3px;
-	padding-left:	4px;
-	padding-right:	8px;
-	margin-right:	-5px;
-	margin-left:	-5px;
-	margin-top:		0px;
-	margin-bottom:	0px;
+	border-radius: 5px !important;
+	padding-top: 3px;
+	padding-bottom: 3px;
+	padding-left: 4px;
+	padding-right: 8px;
+	margin-right: -5px;
+	margin-left: -5px;
+	margin-top: 0;
+	margin-bottom: 0;
 }
-
 td.ombi-btn-td {
-	padding-top:	4px !important;
-	padding-bottom:	4px !important;
+	padding-top: 4px !important;
+	padding-bottom: 4px !important;
 }
-
 .btn-ombi.disabled {
 	 color: darkgrey !important;
 	 cursor: not-allowed;
 }
-
 .fa-slightlybigger {
-	font-size:	125%;
+	font-size: 125%;
 }
-
 .label-ombi-quality {
-	font-weight:	bolder;
-	border-radius:	3px !important;
+	font-weight: bolder;
+	border-radius: 3px !important;
 }
-
 .tooltip.in {
 	opacity: 0.95;
 	font-size: 90%;

--- a/interfaces/default/css/plex.css
+++ b/interfaces/default/css/plex.css
@@ -1,131 +1,126 @@
 a:Hover {
-    text-decoration: none;
+	text-decoration: none;
 }
 .thumbnails li {
-    position: relative;
+	position: relative;
 	float: left !important;
 }
 #movie-grid img.thumbnail,
 #show-grid img.thumbnail {
-    height: 150px;
-    width: 100px;
+	height: 150px;
+	width: 100px;
 }
 #episode-grid img.thumbnail {
-    position: relative;
-    height: 85px;
-    width: 150px;
+	position: relative;
+	height: 85px;
+	width: 150px;
 }
 #album-grid img.thumbnail,
 #artist-grid img.thumbnail {
-    height: 150px;
-    width: 150px;
+	height: 150px;
+	width: 150px;
 }
 #pvr-grid img.thumbnail {
-    height: 75px;
-    width: 75px;
+	height: 75px;
+	width: 75px;
 }
 .watched {
-    position: absolute;
-    top: 138px;
-    right: 5px;
-    width: 16px;
-    height: 16px;
+	position: absolute;
+	top: 138px;
+	right: 5px;
+	width: 16px;
+	height: 16px;
 }
 .watched_episode {
-    position: absolute;
-    top: 73px;
-    right: 5px;
-    width: 16px;
-    height: 16px;
+	position: absolute;
+	top: 73px;
+	right: 5px;
+	width: 16px;
+	height: 16px;
 }
 .grid-caption {
-    position: absolute;
-    bottom: 1px;
-    left: 1px;
-    background: rgba(0,0,0,0.75);
-    padding: 10px;
-    width: 130px;
-    height: 130px;
+	position: absolute;
+	bottom: 1px;
+	left: 1px;
+	background: rgba(0,0,0,0.75);
+	padding: 10px;
+	width: 130px;
+	height: 130px;
 }
 .grid-caption h6 {
-    color: #fff;
-    font-family: inherit;
-    margin: 0;
+	color: #fff;
+	font-family: inherit;
+	margin: 0;
 }
 .grid-caption h6.artist {
-    font-weight: normal;
+	font-weight: normal;
 }
 .grid-control {
-    position: absolute;
-    bottom: 10px;
-    left: 10px;
+	position: absolute;
+	bottom: 10px;
+	left: 10px;
 }
 .grid-control a:first-child {
-    margin-right: 35px;
+	margin-right: 35px;
 }
 h6.title {
-    text-align: center;
-    margin: 0;
-    padding-top: 4px;
+	text-align: center;
+	margin: 0;
+	padding-top: 4px;
 }
 #artist-grid tr td:first-child {
-    width: 35px;
+	width: 35px;
 }
 #artist-grid a.artist-link {
-    display: block;
+	display: block;
 }
 #artist-grid i,
 #playlist-table i {
-    margin: 0 5px 0 0;
+	margin: 0 5px 0 0;
 }
 #nowplaying #player-progressbar,
 #playlist tr td {
-    cursor: pointer;
+	cursor: pointer;
 }
 #nowplaying {
-    background-size: 100%;
-    background-position: 50% 20%;
-    background-repeat: no-repeat;
-    margin-bottom: 10px;
+	background-size: 100%;
+	background-position: 50% 20%;
+	background-repeat: no-repeat;
+	margin-bottom: 10px;
 }
 #playlist-table tr td:last-child {
-    width: 35px;
+	width: 35px;
 }
-
 .modal-fanart {
-    background: #fff top center no-repeat;
-    background-size: 100%;
+	background: #fff top center no-repeat;
+	background-size: 100%;
 }
 .modal .movie-poster {
-    height: 300px;
-    width: 200px;
+	height: 300px;
+	width: 200px;
 }
 .modal .modal-movieinfo {
-    margin-left: 230px;
+	margin-left: 230px;
 }
-
-
 .modal .modal-episodeinfo {
-    margin-left: 230px;
+	margin-left: 230px;
 }
-
 .modal .modal-youtube {
-    border: 0;
-    height: 375px;
+	border: 0;
+	height: 375px;
 	width: 100%;
 	overflow: hidden;
 }
-
 @media (max-width: 767px) {
-	.thumbnails>li{margin-left:4px}
+	.thumbnails > li {
+		margin-left: 4px
 	}
-
-
+}
 @media (max-width: 320px) {
 	.modal .movie-poster {
 		height: 151px !important;
 		width: 104px !important;
-        margin-right: 8px;
+		margin-right: 8px;
 	}
 	.modal-body {
 		max-height: 280px;
@@ -134,32 +129,30 @@ h6.title {
 		max-height: 200px;
 	}
 	.thumbnails>li {
-		padding: 0px;
+		padding: 0;
 		margin-left: 12px;
 	}
-    .thumbnail {
-        margin:15px;
-    }
-
+	.thumbnail {
+		margin:15px;
+	}
 	.modal .thumbnail {
-        margin: 0px 8px 0px 0px;
+		margin: 0 8px 0 0;
 	}
 	.modal .modal-movieinfo {
-		margin-left: 0px;
+		margin-left: 0;
 	}
-    #episode-grid.thumbnails>li {
-        padding: 0px;
-        margin-left: 63px !important;
-
-    }
-    .modal .modal-episodeinfo {
-    margin-left: 0px;
-}
-    .modal .episode-poster {
-        height: 100px !important;
-        width: 150px !important;
-    }
-    #episode-grid > li  .thumbnail {
-        margin:0px;
-    }
+	#episode-grid.thumbnails>li {
+		padding: 0;
+		margin-left: 63px !important;
+	}
+	.modal .modal-episodeinfo {
+		margin-left: 0;
+	}
+	.modal .episode-poster {
+		height: 100px !important;
+		width: 150px !important;
+	}
+	#episode-grid > li .thumbnail {
+		margin: 0;
+	}
 }

--- a/interfaces/default/css/plexpy.css
+++ b/interfaces/default/css/plexpy.css
@@ -1,150 +1,130 @@
 .p-sm {
-    padding: 5px;
+	padding: 5px;
 }
-
 .p-l-md {
-    padding-left: 10px;
+	padding-left: 10px;
 }
-
 .p-lr-sm {
-    padding-left: 5px;
-    padding-right: 5px;
+	padding-left: 5px;
+	padding-right: 5px;
 }
-
 .small-font {
-    font-size: 15px;
+	font-size: 15px;
 }
-
 .progress {
-    margin-bottom: 0 !important;
-    margin-top: -40px;
+	margin-bottom: 0 !important;
+	margin-top: -40px;
 }
-
 .top-title {
-    position: relative;
-    background-color: rgba(255, 255, 255, 0.9);
-    color: #000000;
-    margin-top: 10px;
+	position: relative;
+	background-color: rgba(255, 255, 255, 0.9);
+	color: #000000;
+	margin-top: 10px;
 }
 #history_table {
-    color: #000000;
+	color: #000000;
 }
 #history_table th{
-    background-color: #f2f2f2;
+	background-color: #f2f2f2;
 }
-
 /* .poster-image {
-  min-height: 200px;
+	min-height: 200px;
 } */
-
 .plexpy-poster {
-    position: relative;
-    opacity: 1;
-    display: block; 
-    width: 100%; 
-/*    backface-visibility: hidden; */
+	position: relative;
+	opacity: 1;
+	display: block;
+	width: 100%;
+	/* backface-visibility: hidden; */
 }
-
 .plexpy-poster:hover .poster-image {
-    min-height: 200px;
-    min-width: 345px;
-    opacity: 0.2;
+	min-height: 200px;
+	min-width: 345px;
+	opacity: 0.2;
 }
-
 .plexpy-poster:hover .meta-overlay-full {
-    min-width: 400px;
-    visibility: visible;
+	min-width: 400px;
+	visibility: visible;
 }
-
 .meta-overlay-full {
-    position: relative;
-    top: -200px;
-    height: 40px; 
-    padding-left: 5px;
-    padding-right: 5px;
-    color: #f2f2f2;
-    font-size: small;
-    visibility: hidden;
+	position: relative;
+	top: -200px;
+	height: 40px;
+	padding-left: 5px;
+	padding-right: 5px;
+	color: #f2f2f2;
+	font-size: small;
+	visibility: hidden;
 }
-
 .meta-overlay {
-    position: relative;
-    padding-left: 5px;
-    padding-right: 5px;
-    top: -40px;
-    background-color: rgba(10, 10, 10, 0.6);
-    color: #f2f2f2;
-    font-size: small;
-    font-weight: bold;
-    visibility: hidden;
+	position: relative;
+	padding-left: 5px;
+	padding-right: 5px;
+	top: -40px;
+	background-color: rgba(10, 10, 10, 0.6);
+	color: #f2f2f2;
+	font-size: small;
+	font-weight: bold;
+	visibility: hidden;
 }
-
 ul.meta {
-    list-style:none;
-    margin:0;
-    padding:0;
-    width:100%;
-    overflow:hidden;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	width: 100%;
+	overflow: hidden;
 }
 li.meta-right {
-    white-space: nowrap;
+	white-space: nowrap;
 }
-
 li.meta-left {
-    width: 20%;
-    padding-right: 8px;
-    float: left;
-    min-width:85px;
+	width: 20%;
+	padding-right: 8px;
+	float: left;
+	min-width: 85px;
 }
-
 li.meta-span {
-    width:100%;
-    max-width: 325px;
-    font-size:smaller;
+	width: 100%;
+	max-width: 325px;
+	font-size: smaller;
 }
-
-.stat-holder{
-    height: 145px;
+.stat-holder {
+	height: 145px;
 }
-
 .stat-poster {
-    width: 80px;
-    height: 120px;
-    border: 2px solid #f6f6f6;
+	width: 80px;
+	height: 120px;
+	border: 2px solid #f6f6f6;
 }
-
 .stat-highlights {
-    margin-left: 100px;
-    color: #ffffff;
+	margin-left: 100px;
+	color: #ffffff;
 }
-
 .stat-highlights h2, h3 {
-    color: #ffffff;
+	color: #ffffff;
 }
-
 .stat-highlights h3 {
-    display: inline;
+	display: inline;
 }
-
 .fa-white {
-    color: #ffffff;
+	color: #ffffff;
 }
 .dt-history-table{
-    font-size: small;
+	font-size: small;
 }
 td.no-wrap, th.no-wrap {
-    white-space: nowrap;
+	white-space: nowrap;
 }
 .stat-cover {
-    width: 80px;
-    height: 80px;
-    border: 2px solid #f6f6f6;
-    margin-top: 20px;
+	width: 80px;
+	height: 80px;
+	border: 2px solid #f6f6f6;
+	margin-top: 20px;
 }
 #watchstats{
-    padding-top: 10px;
-    border-top: 2px solid #c4c4c4;
+	padding-top: 10px;
+	border-top: 2px solid #c4c4c4;
 }
 #activity{
-    margin-top: -20px;
+	margin-top: -20px;
 }

--- a/interfaces/default/css/qbittorrent.css
+++ b/interfaces/default/css/qbittorrent.css
@@ -1,36 +1,28 @@
 #qbt_rp_icon {
-  display:inline-block;
-	line-height:inherit;
+	display: inline-block;
+	line-height: inherit;
 }
 .ofa {
-	overflow:auto;
+	overflow: auto;
 }
 table {
 	margin-bottom: 10px !important;
 }
-
-/**
- * Progress bars with centered text
- */
+/* Progress bars with centered text */
 .progress {
-    position: relative;
-    margin-bottom: 0px;
+	position: relative;
+	margin-bottom: 0;
 }
-
 .bar {
-    z-index: 1;
-    position: absolute;
+	z-index: 1;
+	position: absolute;
 }
-
 .progress span {
-    position: absolute;
-    top: 0;
-    z-index: 2;
-    text-align: center;
-    width: 100%;
-    color: black;
+	position: absolute;
+	top: 0;
+	z-index: 2;
+	text-align: center;
+	width: 100%;
+	color: black;
 }
-/*
-end progress bar
-*/
-
+/* end progress bar */

--- a/interfaces/default/css/radarr_view.css
+++ b/interfaces/default/css/radarr_view.css
@@ -1,69 +1,60 @@
-.radarr_movie .banner{
-  position: relative;
-  border-radius: 6px 0px 0px 6px;
-  background:  center left no-repeat ;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
+.radarr_movie .banner {
+	position: relative;
+	border-radius: 6px 0 0 6px;
+	background: center left no-repeat ;
+	-webkit-background-size: cover;
+	-moz-background-size: cover;
+	-o-background-size: cover;
+	background-size: cover;
 }
-
 .radarr_movie .banner .movie_details {
-    background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-    color: White;
-    overflow:hidden;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	color: White;
+	overflow: hidden;
 }
-.radarr_movie .banner .movie_details #movie_details_top{
-  background: Red;
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  top: -15px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 6px 6px 0px 0px;
+.radarr_movie .banner .movie_details #movie_details_top {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	top: -15px;
+	background: Red;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 6px 6px 0 0;
 }
-
-.radarr_movie .banner .movie_details #movie_details_bottom{
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  margin-left: 0px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 0px 0px 6px 6px;
+.radarr_movie .banner .movie_details #movie_details_bottom {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	margin-left: 0;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 0 0 6px 6px;
 }
-
-.radarr_movie .banner .movie_details td{
-  padding: 2px 5px;
+.radarr_movie .banner .movie_details td {
+	padding: 2px 5px;
 }
-
 .radarr_movie .banner .movie_details table,
 .radarr_movie .banner .movie_details strong {
-  margin:10px;
+	margin: 10px;
 }
 strong {
 	line-height: 10px !important;
 	vertical-align: bottom !important;
 }
-@media all and  (max-width: 767px) {
-  /*
-   * On small screens, remove top and bottom round bars on movie-detail block
-   */
-  .radarr_movie .banner .movie_details #movie_details_bottom,
-  .radarr_movie .banner .movie_details #movie_details_top{
-    display: none;
-  }
-  /*
-   * On small screens, Add rounded corners on all sides on banner and detail-box
-   */
-  .radarr_movie .banner .movie_details,
-  .radarr_movie .banner{
-    border-radius: 6px;
-  }
+@media all and (max-width: 767px) {
+	/* On small screens, remove top and bottom round bars on movie-detail block */
+	.radarr_movie .banner .movie_details #movie_details_bottom,
+	.radarr_movie .banner .movie_details #movie_details_top {
+		display: none;
+	}
+	/* On small screens, Add rounded corners on all sides on banner and detail-box */
+	.radarr_movie .banner .movie_details,
+	.radarr_movie .banner {
+		border-radius: 6px;
+	}
 }
-
 .radarr_trailer {
-    margin: 10px auto;
-    width: 50%;
+	margin: 10px auto;
+	width: 50%;
 }

--- a/interfaces/default/css/rtorrent.css
+++ b/interfaces/default/css/rtorrent.css
@@ -1,3 +1,3 @@
 #torrent-queue .progress {
-  margin-bottom: 0px !important;
+	margin-bottom: 0 !important;
 }

--- a/interfaces/default/css/sabnzbd.css
+++ b/interfaces/default/css/sabnzbd.css
@@ -1,19 +1,15 @@
 #sabnzbd-stats .progress,
 #sabnzbd-stats h6 {
-  margin-bottom: 0px;
+	margin-bottom: 0;
 }
-
 #sabnzbd-stats .progress .bar {
-  overflow: hidden;
+	overflow: hidden;
 }
-
 /* sabnzbd table progress bar */
 tr > td:nth-child(3) > div {
-	margin-bottom: 0px;
-
+	margin-bottom: 0;
 }
-
 /* sabnzbd table dropdown */
 #active_table_body > tr > td:nth-child(2) > select {
-	margin-bottom: 0px;
+	margin-bottom: 0;
 }

--- a/interfaces/default/css/samsungtv.css
+++ b/interfaces/default/css/samsungtv.css
@@ -1,83 +1,76 @@
-
 table.samsung_tvremote td{
-	border-top: 0px none #ddd !important;
+	border-top: 0 none #ddd !important;
 	text-align: center;
 }
-
 button {
-	width:72px;
-	height:30px;
+	width: 72px;
+	height: 30px;
 }
-
 .btn2 {
-	width:54px !important;
-	height:30px !important;
+	width: 54px !important;
+	height: 30px !important;
 }
-
 .btn-red {
-  background-color: hsl(360, 100%, 37%);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#fe2d2d", endColorstr="#bc0000");
-  background-image: -khtml-gradient(linear, left top, left bottom, from(#fe2d2d), to(#bc0000));
-  background-image: -moz-linear-gradient(top, #fe2d2d, #bc0000);
-  background-image: -ms-linear-gradient(top, #fe2d2d, #bc0000);
-  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fe2d2d), color-stop(100%, #bc0000));
-  background-image: -webkit-linear-gradient(top, #fe2d2d, #bc0000);
-  background-image: -o-linear-gradient(top, #fe2d2d, #bc0000);
-  background-image: linear-gradient(#fe2d2d, #bc0000);
-  border-color: #bc0000 #bc0000 hsl(360, 100%, 31.5%);
-  color: #fff;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.36);
-  -webkit-font-smoothing: antialiased;
+	background-color: hsl(360, 100%, 37%);
+	background-repeat: repeat-x;
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#fe2d2d", endColorstr="#bc0000");
+	background-image: -khtml-gradient(linear, left top, left bottom, from(#fe2d2d), to(#bc0000));
+	background-image: -moz-linear-gradient(top, #fe2d2d, #bc0000);
+	background-image: -ms-linear-gradient(top, #fe2d2d, #bc0000);
+	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fe2d2d), color-stop(100%, #bc0000));
+	background-image: -webkit-linear-gradient(top, #fe2d2d, #bc0000);
+	background-image: -o-linear-gradient(top, #fe2d2d, #bc0000);
+	background-image: linear-gradient(#fe2d2d, #bc0000);
+	border-color: #bc0000 #bc0000 hsl(360, 100%, 31.5%);
+	color: #fff;
+	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.36);
+	-webkit-font-smoothing: antialiased;
 }
-
 .btn-green {
-  background-color: hsl(98, 62%, 37%);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#85d755", endColorstr="#4e9823");
-  background-image: -khtml-gradient(linear, left top, left bottom, from(#85d755), to(#4e9823));
-  background-image: -moz-linear-gradient(top, #85d755, #4e9823);
-  background-image: -ms-linear-gradient(top, #85d755, #4e9823);
-  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #85d755), color-stop(100%, #4e9823));
-  background-image: -webkit-linear-gradient(top, #85d755, #4e9823);
-  background-image: -o-linear-gradient(top, #85d755, #4e9823);
-  background-image: linear-gradient(#85d755, #4e9823);
-  border-color: #4e9823 #4e9823 hsl(98, 62%, 31.5%);
-  color: #fff;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.36);
-  -webkit-font-smoothing: antialiased;
+	background-color: hsl(98, 62%, 37%);
+	background-repeat: repeat-x;
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#85d755", endColorstr="#4e9823");
+	background-image: -khtml-gradient(linear, left top, left bottom, from(#85d755), to(#4e9823));
+	background-image: -moz-linear-gradient(top, #85d755, #4e9823);
+	background-image: -ms-linear-gradient(top, #85d755, #4e9823);
+	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #85d755), color-stop(100%, #4e9823));
+	background-image: -webkit-linear-gradient(top, #85d755, #4e9823);
+	background-image: -o-linear-gradient(top, #85d755, #4e9823);
+	background-image: linear-gradient(#85d755, #4e9823);
+	border-color: #4e9823 #4e9823 hsl(98, 62%, 31.5%);
+	color: #fff;
+	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.36);
+	-webkit-font-smoothing: antialiased;
 }
-
 .btn-yellow {
-  background-color: hsl(66, 84%, 37%);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#dcee3e", endColorstr="#9dad0f");
-  background-image: -khtml-gradient(linear, left top, left bottom, from(#dcee3e), to(#9dad0f));
-  background-image: -moz-linear-gradient(top, #dcee3e, #9dad0f);
-  background-image: -ms-linear-gradient(top, #dcee3e, #9dad0f);
-  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #dcee3e), color-stop(100%, #9dad0f));
-  background-image: -webkit-linear-gradient(top, #dcee3e, #9dad0f);
-  background-image: -o-linear-gradient(top, #dcee3e, #9dad0f);
-  background-image: linear-gradient(#dcee3e, #9dad0f);
-  border-color: #9dad0f #9dad0f hsl(66, 84%, 31.5%);
-  color: #fff;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.36);
-  -webkit-font-smoothing: antialiased;
+	background-color: hsl(66, 84%, 37%);
+	background-repeat: repeat-x;
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#dcee3e", endColorstr="#9dad0f");
+	background-image: -khtml-gradient(linear, left top, left bottom, from(#dcee3e), to(#9dad0f));
+	background-image: -moz-linear-gradient(top, #dcee3e, #9dad0f);
+	background-image: -ms-linear-gradient(top, #dcee3e, #9dad0f);
+	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #dcee3e), color-stop(100%, #9dad0f));
+	background-image: -webkit-linear-gradient(top, #dcee3e, #9dad0f);
+	background-image: -o-linear-gradient(top, #dcee3e, #9dad0f);
+	background-image: linear-gradient(#dcee3e, #9dad0f);
+	border-color: #9dad0f #9dad0f hsl(66, 84%, 31.5%);
+	color: #fff;
+	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.36);
+	-webkit-font-smoothing: antialiased;
 }
-
 .btn-blue {
-  background-color: hsl(212, 84%, 37%);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#3e90ee", endColorstr="#0f59ad");
-  background-image: -khtml-gradient(linear, left top, left bottom, from(#3e90ee), to(#0f59ad));
-  background-image: -moz-linear-gradient(top, #3e90ee, #0f59ad);
-  background-image: -ms-linear-gradient(top, #3e90ee, #0f59ad);
-  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #3e90ee), color-stop(100%, #0f59ad));
-  background-image: -webkit-linear-gradient(top, #3e90ee, #0f59ad);
-  background-image: -o-linear-gradient(top, #3e90ee, #0f59ad);
-  background-image: linear-gradient(#3e90ee, #0f59ad);
-  border-color: #0f59ad #0f59ad hsl(212, 84%, 31.5%);
-  color: #fff;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.36);
-  -webkit-font-smoothing: antialiased;
+	background-color: hsl(212, 84%, 37%);
+	background-repeat: repeat-x;
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#3e90ee", endColorstr="#0f59ad");
+	background-image: -khtml-gradient(linear, left top, left bottom, from(#3e90ee), to(#0f59ad));
+	background-image: -moz-linear-gradient(top, #3e90ee, #0f59ad);
+	background-image: -ms-linear-gradient(top, #3e90ee, #0f59ad);
+	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #3e90ee), color-stop(100%, #0f59ad));
+	background-image: -webkit-linear-gradient(top, #3e90ee, #0f59ad);
+	background-image: -o-linear-gradient(top, #3e90ee, #0f59ad);
+	background-image: linear-gradient(#3e90ee, #0f59ad);
+	border-color: #0f59ad #0f59ad hsl(212, 84%, 31.5%);
+	color: #fff;
+	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.36);
+	-webkit-font-smoothing: antialiased;
 }

--- a/interfaces/default/css/settings.css
+++ b/interfaces/default/css/settings.css
@@ -1,4 +1,4 @@
 .settingstooltip {
-	margin: 4px 4px 0px 10px !important;
+	margin: 4px 4px 0 10px !important;
 	line-height: normal
 }

--- a/interfaces/default/css/sickbeard_view.css
+++ b/interfaces/default/css/sickbeard_view.css
@@ -1,70 +1,59 @@
-.sickbeard_show .banner{
-  position: relative;
-  border-radius: 6px 0px 0px 6px;
-  background:  center left no-repeat ;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
+.sickbeard_show .banner {
+	position: relative;
+	border-radius: 6px 0 0 6px;
+	background:  center left no-repeat ;
+	-webkit-background-size: cover;
+	-moz-background-size: cover;
+	-o-background-size: cover;
+	background-size: cover;
 }
-
 .sickbeard_show .banner .show_details {
-    background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-    color: White;
-    overflow:hidden;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	color: White;
+	overflow: hidden;
 }
-.sickbeard_show .banner .show_details #show_details_top{
-  background: Red;
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  top: -15px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 6px 6px 0px 0px;
+.sickbeard_show .banner .show_details #show_details_top {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	top: -15px;
+	background: Red;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 6px 6px 0 0;
 }
-
-.sickbeard_show .banner .show_details #show_details_bottom{
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  margin-left: 0px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 0px 0px 6px 6px;
+.sickbeard_show .banner .show_details #show_details_bottom {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	margin-left: 0;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 0 0 6px 6px;
 }
-
-.sickbeard_show .banner .show_details td{
-  padding: 2px 5px;
+.sickbeard_show .banner .show_details td {
+	padding: 2px 5px;
 }
-
 .sickbeard_show .banner .show_details table,
 .sickbeard_show .banner .show_details strong {
-  margin:10px;
+	margin: 10px;
 }
-
-@media all and  (max-width: 767px) {
-  /*
-   * On small screens, remove top and bottom round bars on show-detail block
-   */
-  .sickbeard_show .banner .show_details #show_details_bottom,
-  .sickbeard_show .banner .show_details #show_details_top{
-    display: none;
-  }
-  /*
-   * On small screens, Add rounded corners on all sides on banner and detail-box
-   */
-  .sickbeard_show .banner .show_details,
-  .sickbeard_show .banner{
-    border-radius: 6px;
-  }
+@media all and (max-width: 767px) {
+	/* On small screens, remove top and bottom round bars on show-detail block */
+	.sickbeard_show .banner .show_details #show_details_bottom,
+	.sickbeard_show .banner .show_details #show_details_top {
+		display: none;
+	}
+	/* On small screens, Add rounded corners on all sides on banner and detail-box */
+	.sickbeard_show .banner .show_details,
+	.sickbeard_show .banner {
+		border-radius: 6px;
+	}
 }
-
 .episodeinfo tr {
 	border-bottom: 1px solid #CCCCCC;
 }
-
-.episodeinfo  td {
+.episodeinfo td {
 	width: auto;
 	padding-right: 20px;
 }

--- a/interfaces/default/css/sickrage_view.css
+++ b/interfaces/default/css/sickrage_view.css
@@ -1,85 +1,71 @@
-.sickrage_show .banner{
-  position: relative;
-  border-radius: 6px 0px 0px 6px;
-  background:  center left no-repeat ;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
+.sickrage_show .banner {
+	position: relative;
+	border-radius: 6px 0 0 6px;
+	background: center left no-repeat ;
+	-webkit-background-size: cover;
+	-moz-background-size: cover;
+	-o-background-size: cover;
+	background-size: cover;
 }
-
 .sickrage_show .banner .show_details {
-    background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-    color: White;
-    overflow:hidden;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	color: White;
+	overflow:hidden;
 }
-.sickrage_show .banner .show_details #show_details_top{
-  background: Red;
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  top: -15px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 6px 6px 0px 0px;
+.sickrage_show .banner .show_details #show_details_top {
+	background: Red;
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	top: -15px;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 6px 6px 0 0;
 }
-
-.sickrage_show .banner .show_details #show_details_bottom{
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  margin-left: 0px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 0px 0px 6px 6px;
+.sickrage_show .banner .show_details #show_details_bottom {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	margin-left: 0;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 0 0 6px 6px;
 }
-
 /*
 .qltyselector {
-  height: 25px;
-  width: 100px;
+	height: 25px;
+	width: 100px;
 }
-
 .qltybtn {
-  height: 25px;
+	height: 25px;
 }
-
 .editshowform .control-group {
-  margin-bottom: 0px !important;
+	margin-bottom: 0 !important;
 }
 */
-
-.sickrage_show .banner .show_details td{
-  padding: 2px 5px;
+.sickrage_show .banner .show_details td {
+	padding: 2px 5px;
 }
-
 .sickrage_show .banner .show_details table,
 .sickrage_show .banner .show_details strong {
-  margin:10px;
+	margin:10px;
 }
-
-@media all and  (max-width: 767px) {
-  /*
-   * On small screens, remove top and bottom round bars on show-detail block
-   */
-  .sickrage_show .banner .show_details #show_details_bottom,
-  .sickrage_show .banner .show_details #show_details_top{
-    display: none;
-  }
-  /*
-   * On small screens, Add rounded corners on all sides on banner and detail-box
-   */
-  .sickrage_show .banner .show_details,
-  .sickrage_show .banner{
-    border-radius: 6px;
-  }
+@media all and (max-width: 767px) {
+	/* On small screens, remove top and bottom round bars on show-detail block */
+	.sickrage_show .banner .show_details #show_details_bottom,
+	.sickrage_show .banner .show_details #show_details_top {
+		display: none;
+	}
+	/* On small screens, Add rounded corners on all sides on banner and detail-box */
+	.sickrage_show .banner .show_details,
+	.sickrage_show .banner {
+		border-radius: 6px;
+	}
 }
-
 .episodeinfo tr {
 	border-bottom: 1px solid #CCCCCC;
 }
-
-.episodeinfo  td {
+.episodeinfo td {
 	width: auto;
 	padding-right: 20px;
 }

--- a/interfaces/default/css/sonarr.css
+++ b/interfaces/default/css/sonarr.css
@@ -1,31 +1,25 @@
-/**
- * Progress bars with centered text
- */
+/* Progress bars with centered text */
 .progress {
     position: relative;
-    margin-bottom: 0px;
+    margin-bottom: 0;
 }
-
 .bar {
     z-index: 1;
     position: absolute;
 }
-
 .progress span {
-    position: absolute;
-    top: 0;
-    z-index: 2;
-    text-align: center;
-    width: 100%;
-    color: black;
+	position: absolute;
+	top: 0;
+	z-index: 2;
+	text-align: center;
+	width: 100%;
+	color: black;
 }
-
 span.icon-sonarr {
 	cursor: default;
 }
-
 span.disabled {
 	cursor: not-allowed!important;
-    opacity: 0.7;
+	opacity: 0.7;
 	color: grey;
 }

--- a/interfaces/default/css/sonarr_view.css
+++ b/interfaces/default/css/sonarr_view.css
@@ -1,73 +1,63 @@
-.sonarr_show .banner{
-  position: relative;
-  border-radius: 6px 0px 0px 6px;
-  background:  center left no-repeat ;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
+.sonarr_show .banner {
+	position: relative;
+	border-radius: 6px 0 0 6px;
+	background: center left no-repeat ;
+	-webkit-background-size: cover;
+	-moz-background-size: cover;
+	-o-background-size: cover;
+	background-size: cover;
 }
-
 .sonarr_show .banner .show_details {
-    background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-    color: White;
-    overflow:hidden;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	color: White;
+	overflow: hidden;
 }
-.sonarr_show .banner .show_details #show_details_top{
-  background: Red;
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  top: -15px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 6px 6px 0px 0px;
+.sonarr_show .banner .show_details #show_details_top {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	top: -15px;
+	background: Red;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 6px 6px 0 0;
 }
-
-.sonarr_show .banner .show_details #show_details_bottom{
-  display: block;
-  height: 15px;
-  min-height: 10px;
-  position: absolute;
-  margin-left: 0px;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
-  border-radius: 0px 0px 6px 6px;
+.sonarr_show .banner .show_details #show_details_bottom {
+	display: block;
+	height: 15px;
+	min-height: 10px;
+	position: absolute;
+	margin-left: 0;
+	background: none repeat scroll 0 0 rgba(0, 0, 0, 0.5);
+	border-radius: 0 0 6px 6px;
 }
-
-.sonarr_show .banner .show_details td{
-  padding: 2px 5px;
+.sonarr_show .banner .show_details td {
+	padding: 2px 5px;
 }
-
 .sonarr_show .banner .show_details table,
 .sonarr_show .banner .show_details strong {
-  margin:10px;
+	margin:10px;
 }
 strong {
 	line-height: 10px !important;
 	vertical-align: bottom !important;
 }
-@media all and  (max-width: 767px) {
-  /*
-   * On small screens, remove top and bottom round bars on show-detail block
-   */
-  .sonarr_show .banner .show_details #show_details_bottom,
-  .sonarr_show .banner .show_details #show_details_top{
-    display: none;
-  }
-  /*
-   * On small screens, Add rounded corners on all sides on banner and detail-box
-   */
-  .sonarr_show .banner .show_details,
-  .sonarr_show .banner{
-    border-radius: 6px;
-  }
+@media all and (max-width: 767px) {
+	/* On small screens, remove top and bottom round bars on show-detail block */
+	.sonarr_show .banner .show_details #show_details_bottom,
+	.sonarr_show .banner .show_details #show_details_top {
+		display: none;
+	}
+	/* On small screens, Add rounded corners on all sides on banner and detail-box */
+	.sonarr_show .banner .show_details,
+	.sonarr_show .banner {
+		border-radius: 6px;
+	}
 }
-
 .episodeinfo tr {
 	border-bottom: 1px solid #CCCCCC;
 }
-
-.episodeinfo  td {
+.episodeinfo td {
 	width: auto;
 	padding-right: 20px;
 }

--- a/interfaces/default/css/stats.css
+++ b/interfaces/default/css/stats.css
@@ -2,58 +2,59 @@ h1.page-header.page-title {
 	margin: -20px -20px 5px;
 }
 .table.nwtable td{
-	padding:0px !important;
-	border-top: 0px none #ddd !important;
+	padding: 0 !important;
+	border-top: 0 none #ddd !important;
 	text-align: center;
 }
-
 .disktable {
 	margin: 0.3% 0 0 0 !important;
 }
-
 .table.nwtable {
-	margin-bottom:0px !important;
+	margin-bottom: 0 !important;
 }
-
 td.tlip {
 	font-size: 13px !important;
 }
-
 td.txip {
 	font-size: 13px !important;
 }
-
 table.networktable {
 	table-layout: fixed;
 	word-wrap: break-word !important;
 }
-
 .nwtable tr td{
 	font-weight: 200;
 }
 /* First td should not have the smaller font */
-.nwtable tr td:first-child{
+.nwtable tr td:first-child {
 	text-align: center;
 	font-weight: bold;
 }
-
-
 #disklist > tr > td.span3.stats_disk_progress > div {
-	margin-bottom: 0px;
+	margin-bottom: 0;
 }
-
 #statscmd {
 	margin-top:10px;
 }
-
-.alert.helper-block{
-	margin-bottom: 0px !important;
+.alert.helper-block {
+	margin-bottom: 0 !important;
 }
-
-
-.treegrid-indent {width:16px; height: 16px; display: inline-block; position: relative;}
-
-.treegrid-expander {width:16px; height: 16px; display: inline-block; position: relative; cursor: pointer;}
-
-.treegrid-expander-expanded{background-image: url(../img/collapse.png); }
-.treegrid-expander-collapsed{background-image: url(../img/expand.png);}
+.treegrid-indent {
+	width: 16px;
+	height: 16px;
+	display: inline-block;
+	position: relative;
+}
+.treegrid-expander {
+	width: 16px;
+	height: 16px;
+	display: inline-block;
+	position: relative;
+	cursor: pointer;
+}
+.treegrid-expander-expanded {
+	background-image: url(../img/collapse.png);
+}
+.treegrid-expander-collapsed {
+	background-image: url(../img/expand.png);
+}

--- a/interfaces/default/css/utorrent.css
+++ b/interfaces/default/css/utorrent.css
@@ -1,28 +1,20 @@
 #torrents .progress {
-	margin-bottom: 0px !important;
+	margin-bottom: 0 !important;
 }
-
-
-/**
- * Progress bars with centered text
- */
+/* Progress bars with centered text */
 .progress {
-    position: relative;
+	position: relative;
 }
-
 .bar {
-    z-index: 1;
-    position: absolute;
+	z-index: 1;
+	position: absolute;
 }
-
 .progress span {
-    position: absolute;
-    top: 0;
-    z-index: 2;
-    text-align: center;
-    width: 100%;
-    color: black;
+	position: absolute;
+	top: 0;
+	z-index: 2;
+	text-align: center;
+	width: 100%;
+	color: black;
 }
-/*
-end progressbar center
-*/
+/* end progressbar center */

--- a/interfaces/default/css/vnstat.css
+++ b/interfaces/default/css/vnstat.css
@@ -1,9 +1,8 @@
 canvas {
-  //background-color: blue;
-  //width: 100% !important;
-  //height: auto !important;
+	/* background-color: blue; */
+	/* width: 100% !important; */
+	/* height: auto !important; */
 }
-
 .bwinfocontainer {
 	margin-top: 10px;
 }


### PR DESCRIPTION
This does not change any style, it is only some housekeeping to apply a consistent CSS code and remove some unusual syntax and by this I got some overview over the CSS classes, backwards-compatibility code and doubled code as well:
- Remove unit from zero values, e.g. `0px` => `0`
- Replace uncommon `// ...` line comments with common syntax `/* ... */`
- Apply shorthand values, where possible, e.g. `padding: 1px 1px 1px 1px;` => `padding: 1px;`
- Consequently use tab character for indentation, so that all indents look the same in an editor and their length is a question of the editor setting/coder preference
- Remove double spaces and empty lines, the latter were not used in any consistent way
- Consequently use the optional space after `:` and `,` and before `{`, which was mostly the case already
- Put every `option: value;` pair onto a new line, which was mostly the case, to make nested styles better readable
- There were some doubled `background:` definitions, not sure if the first was meant as fallback for older browsers but I group them together (keeping the order) to make this better visible.