### PR TITLE
Do not assign obsolete/unused S.M.A.R.T. attributes

### DIFF
--- a/modules/stats.py
+++ b/modules/stats.py
@@ -588,11 +588,9 @@ class Stats(object):
                         d[i] = {'assessment': hds.assessment,
                                 'firmware': hds.firmware,
                                 'interface': hds.interface,
-                                'is_ssd': hds.is_ssd,
                                 'model': hds.model,
                                 'name': hds.name,
                                 'serial': hds.serial,
-                                'supports_smart': hds.supports_smart,
                                 'capacity': hds.capacity,
                                 'temperature': temp,
                                 'attributes': a


### PR DESCRIPTION
With newer Python versions, this causes an "object has no attribute 'supports_smart'" error, since pySMART does not provide it. "smart_capable" and "smart_enabled" do exist instead, but currently we do not use it anyway. The value is hence removed completely until someone finds time to re-implement it in a reasonable way, e.g. to enhance error messages when S.M.A.R.T. does not work.