### PR TITLE
Fix cert and key generation for HTTPS

### DIFF
--- a/htpc/helpers.py
+++ b/htpc/helpers.py
@@ -336,17 +336,17 @@ def create_https_certificates(ssl_cert, ssl_key):
     # Create the CA Certificate
     cakey = createKeyPair(TYPE_RSA, 2048)
     careq = createCertRequest(cakey, CN='Certificate Authority')
-    cacert = createCertificate(careq, (careq, cakey), serial, (0, 60 * 60 * 24 * 365 * 10))  # ten years
+    cacert = createCertificate(careq, careq, cakey, serial, 0, 60 * 60 * 24 * 365 * 10)  # ten years
 
     cname = 'Htpc-Manager'
     pkey = createKeyPair(TYPE_RSA, 2048)
     req = createCertRequest(pkey, CN=cname)
-    cert = createCertificate(req, (cacert, cakey), serial, (0, 60 * 60 * 24 * 365 * 10))  # ten years
+    cert = createCertificate(req, cacert, cakey, serial, 0, 60 * 60 * 24 * 365 * 10)  # ten years
 
     # Save the key and certificate to disk
     try:
-        open(ssl_key, 'w').write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey))
-        open(ssl_cert, 'w').write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+        open(ssl_key, 'wb').write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey))
+        open(ssl_cert, 'wb').write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
     except Exception as e:
         logger.error('Error creating SSL key and certificate %s' % e)
         return False

--- a/libs/certgen.py
+++ b/libs/certgen.py
@@ -15,30 +15,28 @@ from OpenSSL import crypto
 import time
 
 TYPE_RSA = crypto.TYPE_RSA
-TYPE_DSA = crypto.TYPE_DSA
-
 serial = int(time.time())
 
 
-def createKeyPair(type, bits):
+def createKeyPair(key_type, bits):
     """
     Create a public/private key pair.
 
-    Arguments: type - Key type, must be one of TYPE_RSA and TYPE_DSA
+    Arguments: key_type - Key type, must be TYPE_RSA as TYPE_DSA is discouraged
                bits - Number of bits to use in the key
     Returns:   The public/private key pair in a PKey object
     """
     pkey = crypto.PKey()
-    pkey.generate_key(type, bits)
+    pkey.generate_key(key_type, bits)
     return pkey
 
 
-def createCertRequest(pkey, digest="md5", **name):
+def createCertRequest(pkey, digest="sha256", **name):
     """
     Create a certificate request.
 
     Arguments: pkey   - The key to associate with the request
-               digest - Digestion method to use for signing, default is md5
+               digest - Digestion method to use for signing, default is sha256
                **name - The name of the subject of the request, possible
                         arguments are:
                           C     - Country name
@@ -61,7 +59,7 @@ def createCertRequest(pkey, digest="md5", **name):
     return req
 
 
-def createCertificate(req, (issuerCert, issuerKey), serial, (notBefore, notAfter), digest="md5"):
+def createCertificate(req, issuerCert, issuerKey, serial, notBefore, notAfter, digest="sha256"):
     """
     Generate a certificate given a certificate request.
 
@@ -73,7 +71,7 @@ def createCertificate(req, (issuerCert, issuerKey), serial, (notBefore, notAfter
                             starts being valid
                notAfter   - Timestamp (relative to now) when the certificate
                             stops being valid
-               digest     - Digest method to use for signing, default is md5
+               digest     - Digest method to use for signing, default is sha256
     Returns:   The signed certificate in an X509 object
     """
     cert = crypto.X509()


### PR DESCRIPTION
MD5 is not accepted anymore by even intermediate OpenSSL versions. SHA256 is a current standard for a longer while. Similarly DSA not seen as insecure nowadays and we didn't use it, hence remove it from the library.

Python 3 does not support self-expanding tuples as function arguments anymore. Also those are unnecessary here. Furthermore cert and key writes need to be done explicitly in bytes type, to match the output buffers given by pyOpenSSL functions.