### PR TITLE
Remove CherryPy version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ requests-futures
 mako
 tzlocal
 xmltodict
-cherrypy<9.0
+cherrypy
 jsonrpclib-pelix
 pytz
 pyasn1


### PR DESCRIPTION
`cheroot` v8.6.0 has been released, used in CherryPy v9.0 and above, which has the high idle CPU load resolved: https://github.com/cherrypy/cheroot/pull/401

Since this was the reason for using a CherryPy<9.0 version dependency, this is hereby removed.